### PR TITLE
Add `baseUrl` App option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ const app = new App({
 })
 ```
 
+## Using with GitHub Enterprise
+
+The `baseUrl` option can be used to override default GitHub's `https://api.github.com`:
+
+```js
+const app = new App({
+  id: APP_ID,
+  privateKey: PRIVATE_KEY,
+  baseUrl: 'https://github-enterprise.com/api/v3'
+}) 
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ const getCache = require('./lib/get-cache')
 const getInstallationAccessToken = require('./lib/get-installation-access-token')
 const getSignedJsonWebToken = require('./lib/get-signed-json-web-token')
 
-function App ({ id, privateKey, cache }) {
+function App ({ id, privateKey, baseUrl, cache }) {
   const state = {
     id,
     privateKey,
-    request,
+    request: baseUrl ? request.defaults({ baseUrl }) : request,
     cache: cache || getCache()
   }
   const api = {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 module.exports = App
 
+const request = require('@octokit/request')
+
 const getCache = require('./lib/get-cache')
 const getInstallationAccessToken = require('./lib/get-installation-access-token')
 const getSignedJsonWebToken = require('./lib/get-signed-json-web-token')
@@ -8,6 +10,7 @@ function App ({ id, privateKey, cache }) {
   const state = {
     id,
     privateKey,
+    request,
     cache: cache || getCache()
   }
   const api = {

--- a/lib/get-installation-access-token.js
+++ b/lib/get-installation-access-token.js
@@ -1,7 +1,5 @@
 module.exports = getInstallationAccessToken
 
-const request = require('@octokit/request')
-
 const getSignedJsonWebToken = require('./get-signed-json-web-token')
 
 // https://developer.github.com/v3/apps/#create-a-new-installation-token
@@ -11,7 +9,7 @@ function getInstallationAccessToken (state, { installationId }) {
     return Promise.resolve(token)
   }
 
-  return request({
+  return state.request({
     method: 'POST',
     url: '/app/installations/:installation_id/access_tokens',
     installation_id: installationId,

--- a/test/test.js
+++ b/test/test.js
@@ -169,4 +169,24 @@ describe('app.js', () => {
         expect(options.cache.set.callCount).to.equal(1)
       })
   })
+
+  it('supports custom base url', () => {
+    nock('https://github-enterprise.com/api/v3')
+      .post('/app/installations/123/access_tokens')
+      .reply(201, {
+        token: 'foo'
+      })
+
+    const options = {
+      id: APP_ID,
+      privateKey: PRIVATE_KEY,
+      baseUrl: 'https://github-enterprise.com/api/v3'
+    }
+    const appWithCustomEndpointDefaults = new App(options)
+
+    return appWithCustomEndpointDefaults.getInstallationAccessToken({ installationId: 123 })
+      .then(token => {
+        expect(token).to.equal('foo')
+      })
+  })
 })


### PR DESCRIPTION
The option can be used to override hardcoded defaults from @octokit/endpoint.

So that we can now use it to work on GitHub Enterprise installations:

```js
const app = new App({
  id: APP_ID,
  privateKey: PRIVATE_KEY,
  baseUrl: 'https://github-enterprise.com/api/v3'
})
```

Closes #13.

-----
[View rendered README.md](https://github.com/anton-rudeshko/app.js/blob/master/README.md)