### PR TITLE
Fixed *.d.ts variable name to match source code

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare interface AppOptions {
 }
 
 declare interface getInstallationAccessTokenOptions {
-  installation_id: number
+  installationId: number
 }
 
 // Not really a class, but it is how they say it should be used in the readme.


### PR DESCRIPTION
Looking at the source code looks like the variable should be `installationId` for `getInstallationAccessTokenOptions` not `installation_id`