### PR TITLE
no body object in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const { data } = await request('GET /repos/:owner/:repo/installation', {
 })
 
 // contains the installation id necessary to authenticate as an installation
-const installationId = body.data.id
+const installationId = data.id
 ```
 
 ## Authenticating as an Installation


### PR DESCRIPTION
The example for fetching the installation id uses a variable `body` that doesn't actually exist.

-----
[View rendered README.md](https://github.com/jbjonesjr/app.js/blob/master/README.md)