### PR TITLE
add expiry parameter to cache.set

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ await request('POST /repos/:owner/:repo/issues', {
 
 Installation tokens expire after an hour. By default, `@octokit/app` is caching up to 15000 tokens simultaneously using [`lru-cache`](https://github.com/isaacs/node-lru-cache). You can pass your own cache implementation by passing `options.cache.{get,set}` to the constructor.
 
-> an optional `expiry` parameter is passed to `cache.set`, useful for further automation of your cache mechanism
-> _e.g. auto purge values after expiry is elapsed._
-
 ```js
 const App = require('@octokit/app')
 const APP_ID = 1
@@ -85,8 +82,30 @@ const app = new App({
     get (key) {
       return CACHE[key]
     },
+    set (key, value) {
+      CACHE[key] = value
+    }
+  }
+})
+```
+
+> **NOTE**: an optional `expiry` parameter is passed to `cache.set`, useful for further automation of your cache mechanism
+> _e.g. auto purge values after expiry is elapsed._
+
+```js
+const app = new App({
+  id: APP_ID,
+  privateKey: PRIVATE_KEY,
+  cache: {
+    get (key) {
+      return CACHE[key]
+    },
     set (key, value, expiry) {
       CACHE[key] = value
+      
+      const timeout = (new Date(expiry)).getTime() - (new Date()).getTime();
+
+      setTimeout(() => delete CACHE[key], timeout)
     }
   }
 })

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ await request('POST /repos/:owner/:repo/issues', {
 
 Installation tokens expire after an hour. By default, `@octokit/app` is caching up to 15000 tokens simultaneously using [`lru-cache`](https://github.com/isaacs/node-lru-cache). You can pass your own cache implementation by passing `options.cache.{get,set}` to the constructor.
 
+> an optional `expiry` parameter is passed to `cache.set`, useful for further automation of your cache mechanism
+> _e.g. auto purge values after expiry is elapsed._
+
 ```js
 const App = require('@octokit/app')
 const APP_ID = 1
@@ -82,7 +85,7 @@ const app = new App({
     get (key) {
       return CACHE[key]
     },
-    set (key, value) {
+    set (key, value, expiry) {
       CACHE[key] = value
     }
   }

--- a/lib/get-cache.js
+++ b/lib/get-cache.js
@@ -4,10 +4,12 @@ module.exports = getCache
 const LRU = require('lru-cache')
 
 function getCache () {
-  return new LRU({
+  const lru = new LRU({
     // cache max. 15000 tokens, that will use less than 10mb memory
     max: 15000,
     // Cache for 1 minute less than GitHub expiry
     maxAge: 1000 * 60 * 59
   })
+
+  return { get: (key) => lru.get(key), set: (key, token) => lru.set(key, token) }
 }

--- a/lib/get-installation-access-token.js
+++ b/lib/get-installation-access-token.js
@@ -19,7 +19,7 @@ function getInstallationAccessToken (state, { installationId }) {
       authorization: `bearer ${getSignedJsonWebToken(state)}`
     }
   }).then(response => {
-    state.cache.set(installationId, response.data.token)
+    state.cache.set(installationId, response.data.token, response.data.expires_at)
     return response.data.token
   })
 }


### PR DESCRIPTION
passing `expires_at` value to the `cache.set` method will allow custom implementation of caching to manage expiry of data based on a TTL approach...

-----
[View rendered README.md](https://github.com/ahmadnassri/app.js/blob/master/README.md)