### PR TITLE
Fix LRU.cache missing type in TypeScript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ jobs:
     - node_js: 8
       script: npm run test
     - node_js: 10
-      env: Node 10, coverage upload
+      env: Node 10, validate Typescript, coverage upload
       script:
         - npm run test
+        - npm run validate:ts
         - npm run coverage:upload
 
     - stage: release

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
-import LRU = require("lru-cache");
+import LRUCache = require("lru-cache");
 
 declare interface AppOptions {
   id: string
   privateKey: string
   baseUrl?: string
-  cache?: LRU.Cache<string, string>
+  cache?: LRUCache<string, string>
 }
 
 declare interface getInstallationAccessTokenOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -384,6 +384,11 @@
         }
       }
     },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -9648,6 +9653,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "pretest": "standard",
     "test": "nyc mocha",
     "coverage": "nyc report --reporter=html && open coverage/index.html",
-    "coverage:upload": "nyc report --reporter=text-lcov | coveralls"
+    "coverage:upload": "nyc report --reporter=text-lcov | coveralls",
+    "validate:ts": "tsc --target es6 --noImplicitAny index.d.ts"
   },
   "repository": "https://github.com/octokit/app.js",
   "author": "Bex Warner",
@@ -25,8 +26,10 @@
     "url": "https://github.com/octokit/app.js/issues"
   },
   "homepage": "https://github.com/octokit/app.js#readme",
+  "types": "index.d.ts",
   "dependencies": {
     "@octokit/request": "^2.1.2",
+    "@types/lru-cache": "^5.1.0",
     "jsonwebtoken": "^8.3.0",
     "lru-cache": "^5.1.1"
   },
@@ -39,6 +42,7 @@
     "nyc": "^13.1.0",
     "semantic-release": "^15.12.1",
     "simple-mock": "^0.8.0",
-    "standard": "^12.0.1"
+    "standard": "^12.0.1",
+    "typescript": "^3.3.3333"
   }
 }


### PR DESCRIPTION
I'm getting an error with TypeScript due to an @octokit/app.js dependency:

```sh
node_modules/@octokit/app/index.d.ts:7:15 - error TS2694: Namespace 'LRUCache' has no exported member 'Cache'.

7   cache?: LRU.Cache<string, string>
```

This fix solved it. Please have a look.