### PR TITLE
feat: Add all API options to `getInstallationAccessToken`

### DIFF
--- a/src/get-installation-access-token.ts
+++ b/src/get-installation-access-token.ts
@@ -1,10 +1,10 @@
 import { getSignedJsonWebToken } from "./get-signed-json-web-token";
-import { State } from "./types";
+import { State, InstallationAccessTokenOptions } from "./types";
 
 // https://developer.github.com/v3/apps/#create-a-new-installation-token
 export function getInstallationAccessToken(
   state: State,
-  { installationId }: { installationId: number }
+  { installationId, repositoryIds, permissions }: InstallationAccessTokenOptions
 ): Promise<string> {
   const token = state.cache.get(installationId);
   if (token) {
@@ -20,7 +20,9 @@ export function getInstallationAccessToken(
         accept: "application/vnd.github.machine-man-preview+json",
         // TODO: cache the installation token if it's been less than 60 minutes
         authorization: `bearer ${getSignedJsonWebToken(state)}`
-      }
+      },
+      repository_ids: repositoryIds,
+      permissions
     })
     .then(response => {
       state.cache.set(installationId, response.data.token);

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,11 +42,47 @@ export interface AppOptions {
       };
 }
 
+export type Read = "none" | "read";
+export type ReadWrite = Read | "write";
+export type ReadWriteAdmin = ReadWrite | "admin";
+
+export type InstallationAccessTokenPermissions = {
+  administration?: ReadWrite;
+  blocking?: ReadWrite;
+  checks?: ReadWrite;
+  content_references?: ReadWrite;
+  contents?: ReadWrite;
+  deployments?: ReadWrite;
+  emails?: ReadWrite;
+  followers?: ReadWrite;
+  gpg_keys?: ReadWrite;
+  issues?: ReadWrite;
+  keys?: ReadWrite;
+  members?: ReadWrite;
+  organization_administration?: ReadWrite;
+  organization_hooks?: ReadWrite;
+  organization_plan?: Read;
+  organization_projects?: ReadWriteAdmin;
+  organization_user_blocking?: ReadWrite;
+  packages?: ReadWrite;
+  pages?: ReadWrite;
+  plan?: Read;
+  pull_requests?: ReadWrite;
+  repository_hooks?: ReadWrite;
+  repository_metadata?: Read;
+  repository_projects?: ReadWriteAdmin;
+  single_file?: ReadWrite;
+  starring?: ReadWrite;
+  statuses?: ReadWrite;
+  team_discussions?: ReadWrite;
+  vulnerability_alerts?: Read;
+  watching?: ReadWrite;
+};
 export type InstallationAccessTokenOptions = {
   /**
    * Find the app’s installation token at https://github.com/apps/<app name>/installations/new. Select the account then copy the number from the end of the URL
    */
   installationId: number;
   repositoryIds?: number[];
-  permissions?: { [permission: string]: string };
+  permissions?: InstallationAccessTokenPermissions;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,4 +47,6 @@ export type InstallationAccessTokenOptions = {
    * Find the app’s installation token at https://github.com/apps/<app name>/installations/new. Select the account then copy the number from the end of the URL
    */
   installationId: number;
+  repositoryIds?: number[];
+  permissions?: { [permission: string]: string };
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,6 +3,7 @@ import nock from "nock";
 import { stub } from "simple-mock";
 
 import { App } from "../src";
+import { InstallationAccessTokenPermissions } from "../src/types";
 const APP_ID = 1;
 const PRIVATE_KEY = `-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEA1c7+9z5Pad7OejecsQ0bu3aozN3tihPmljnnudb9G3HECdnH
@@ -98,7 +99,9 @@ describe("app.js", () => {
   });
 
   it("gets installation token with permissions", () => {
-    let permissions = { single_file: "read" };
+    let permissions: InstallationAccessTokenPermissions = {
+      single_file: "read"
+    };
     nock("https://api.github.com", {
       reqheaders: {
         authorization: `bearer ${BEARER}` // installation access token

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -75,6 +75,52 @@ describe("app.js", () => {
         expect(token).toEqual("foo");
       });
   });
+  it("gets installation token with repository_ids", () => {
+    let repositoryIds = [1];
+    nock("https://api.github.com", {
+      reqheaders: {
+        authorization: `bearer ${BEARER}` // installation access token
+      }
+    })
+      .post("/app/installations/123/access_tokens", body => {
+        expect(body.repository_ids).toEqual(repositoryIds);
+        return true;
+      })
+      .reply(201, {
+        token: "foo"
+      });
+
+    return app
+      .getInstallationAccessToken({ installationId: 123, repositoryIds })
+      .then(token => {
+        expect(token).toEqual("foo");
+      });
+  });
+
+  it("gets installation token with permissions", () => {
+    let permissions = { single_file: "read" };
+    nock("https://api.github.com", {
+      reqheaders: {
+        authorization: `bearer ${BEARER}` // installation access token
+      }
+    })
+      .post("/app/installations/123/access_tokens", body => {
+        expect(body.permissions).toEqual(permissions);
+        return true;
+      })
+      .reply(201, {
+        token: "foo"
+      });
+
+    return app
+      .getInstallationAccessToken({
+        installationId: 123,
+        permissions
+      })
+      .then(token => {
+        expect(token).toEqual("foo");
+      });
+  });
 
   it("gets installation token from cache", () => {
     nock("https://api.github.com")


### PR DESCRIPTION
Add two new options, `repositoryIds` and `permissions`, as allowed by the
API.

https://developer.github.com/v3/apps/#example