### PR TITLE
Change comment to more accurately reflect intent

### DIFF
--- a/src/get-signed-json-web-token.ts
+++ b/src/get-signed-json-web-token.ts
@@ -9,7 +9,7 @@ export function getSignedJsonWebToken({ id, privateKey }: getSignedJWTOptions) {
   const now = Math.floor(Date.now() / 1000);
   const payload = {
     iat: now, // Issued at time
-    exp: now + 60 * 10 - 30, // JWT expiration time (10 minute maximum, 30 seconds of leeway)
+    exp: now + 60 * 10 - 30, // JWT expiration time (10 minute maximum, 30 second safeguard)
     iss: id
   };
   const token = jsonwebtoken.sign(payload, privateKey, { algorithm: "RS256" });


### PR DESCRIPTION
I initially stumbled upon this comment while reviewing a draft blog post for @JasonEtco but I was instantly confused because "leeway" implies adding something for more freedom.  I had to dig back to find the [issue](https://github.com/probot/probot/issues/942) and [PR](https://github.com/octokit/app.js/pull/36) that brought this code about to understand why the subtraction was indeed the intended action.

This subtraction is more of a preventative safety net, or a "30 second safeguard/buffer", to avoid potentially running into the unpleasantness of...

> ...the maximum expiration time of 10 minutes, after which the API will start returning a 401 error. [\[1\]](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app)