### PR TITLE
Add implementation of eachRepository({ installationId }, callback) (fix #188)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -40,10 +40,16 @@ type EachRepositoryFunctionOptions = {
 export type EachRepositoryFunction = (
   options: EachRepositoryFunctionOptions
 ) => unknown | Promise<unknown>;
+export type EachRepositoryQuery = {
+  installationId: number;
+};
 
 export interface EachRepositoryInterface {
   (callback: EachRepositoryFunction): Promise<void>;
-  iterator: () => AsyncIterable<EachRepositoryFunctionOptions>;
+  (query: EachRepositoryQuery, callback: EachRepositoryFunction): Promise<void>;
+  iterator: (
+    query?: EachRepositoryQuery
+  ) => AsyncIterable<EachRepositoryFunctionOptions>;
 }
 
 export interface GetInstallationOctokitInterface {


### PR DESCRIPTION
With this patch, users can optionally pass an installation ID to app.eachRepository to iterate through repositories of one specific installation, as written in README:

```js
for await (const { octokit, repository } of app.eachRepository.iterator({ installationId })) { /* ... */ }
await app.eachRepository({ installationId }, ({ octokit, repository }) => /* ... */)
```

This fixes #188.