### PR TITLE
Fix typo in readme code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const app = new App({
 });
 
 const { data } = await app.octokit.request("/app");
-console.log("authenticated as %s", response.data.name);
+console.log("authenticated as %s", data.name);
 
 for await (const { octokit, repository } of app.eachRepository.iterator()) {
   await octokit.request("POST /repos/{owner}/{repo}/dispatches", {


### PR DESCRIPTION
The `response` variable does not exist. The actual response from the API call is destructured and `data` is extracted.

-----
[View rendered README.md](https://github.com/jstastny/app.js/blob/patch-1/README.md)