### PR TITLE
docs: add reference to reasoning behind the explicit return type

### DIFF
--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -8,7 +8,7 @@ import { Options } from "./types";
 export function webhooks(
   appOctokit: Octokit,
   options: Required<Options>["webhooks"]
-): Webhooks<EmitterWebhookEvent & { octokit: Octokit }> {
+) {
   return new Webhooks({
     secret: options.secret,
     path: "/api/github/webhooks",

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -8,8 +8,8 @@ import { Options } from "./types";
 export function webhooks(
   appOctokit: Octokit,
   options: Required<Options>["webhooks"]
-// Explict return type for better debugability and performance,
-// see https://github.com/octokit/app.js/pull/201
+  // Explict return type for better debugability and performance,
+  // see https://github.com/octokit/app.js/pull/201
 ): Webhooks<EmitterWebhookEvent & { octokit: Octokit }> {
   return new Webhooks({
     secret: options.secret,

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -8,7 +8,9 @@ import { Options } from "./types";
 export function webhooks(
   appOctokit: Octokit,
   options: Required<Options>["webhooks"]
-) {
+// Explict return type for better debugability and performance,
+// see https://github.com/octokit/app.js/pull/201
+): Webhooks<EmitterWebhookEvent & { octokit: Octokit }> {
   return new Webhooks({
     secret: options.secret,
     path: "/api/github/webhooks",


### PR DESCRIPTION
follow up to https://github.com/octokit/app.js/pull/201#issuecomment-780700920