### PR TITLE
feat: `createNodeMiddleware()`. Deprecates `getNodeMiddleware()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - [`app.webhooks`](#appwebhooks)
   - [`app.oauth`](#appoauth)
 - [Middlewares](#middlewares)
-  - [`getNodeMiddleware(app, options)`](#getnodemiddlewareapp-options)
+  - [`createNodeMiddleware(app, options)`](#getnodemiddlewareapp-options)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -46,7 +46,7 @@ Node
 Install with `npm install @octokit/app`
 
 ```js
-const { App, getNodeMiddleware } = require("@octokit/app");
+const { App, createNodeMiddleware } = require("@octokit/app");
 ```
 
 </td></tr>
@@ -94,7 +94,7 @@ app.oauth.on("token", async ({ token, octokit }) => {
   console.log(`Token retrieved for ${data.login}`);
 });
 
-require("http").createServer(getNodeMiddleware(app)).listen(3000);
+require("http").createServer(createNodeMiddleware(app)).listen(3000);
 // can now receive requests at /api/github/*
 ```
 
@@ -302,12 +302,12 @@ By default, all middlewares expose the following routes
 | `DELETE /api/github/oauth/token` | Invalidates current token, basically the equivalent of a logout. Must authenticate using token in `Authorization` header.                                                                                                                                       |
 | `DELETE /api/github/oauth/grant` | Revokes the user's grant, basically the equivalent of an uninstall. must authenticate using token in `Authorization` header.                                                                                                                                    |
 
-### `getNodeMiddleware(app, options)`
+### `createNodeMiddleware(app, options)`
 
 Native http server middleware for Node.js
 
 ```js
-const { App, getNodeMiddleware } = require("@octokit/app");
+const { App, createNodeMiddleware } = require("@octokit/app");
 const app = new App({
   appId: 123,
   privateKey: "-----BEGIN PRIVATE KEY-----\n...",
@@ -320,7 +320,7 @@ const app = new App({
   },
 });
 
-const middleware = getNodeMiddleware(app);
+const middleware = createNodeMiddleware(app);
 
 require("http").createServer(middleware).listen(3000);
 // can now receive user authorization callbacks at /api/github/*

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - [`app.webhooks`](#appwebhooks)
   - [`app.oauth`](#appoauth)
 - [Middlewares](#middlewares)
-  - [`createNodeMiddleware(app, options)`](#getnodemiddlewareapp-options)
+  - [`createNodeMiddleware(app, options)`](#createnodemiddlewareapp-options)
 - [Contributing](#contributing)
 - [License](#license)
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@octokit/oauth-app": "^2.0.1",
     "@octokit/plugin-paginate-rest": "^2.6.0",
     "@octokit/types": "^6.0.3",
-    "@octokit/webhooks": "^8.0.2"
+    "@octokit/webhooks": "^8.0.2",
+    "deprecation": "^2.3.1"
   },
   "devDependencies": {
     "@pika/pack": "^0.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   OAuthApp,
   getNodeMiddleware as oauthNodeMiddleware,
 } from "@octokit/oauth-app";
+import { Deprecation } from "deprecation";
 
 import {
   Options,
@@ -101,7 +102,20 @@ export class App<O extends Options = Options> {
   }
 }
 
+/**
+ * @deprecated use createNodeMiddleware()
+ */
 export function getNodeMiddleware(app: App) {
+  app.log.warn(
+    // @ts-expect-error
+    new Deprecation(
+      "[@octokit/app] getNodeMiddleware is deprecated. Use createNodeMiddleware instead"
+    )
+  );
+  return createNodeMiddleware(app);
+}
+
+export function createNodeMiddleware(app: App) {
   return oauthNodeMiddleware(app.oauth, {
     onUnhandledRequest: (request, response) => {
       return app.webhooks.middleware(request, response);

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -1,0 +1,30 @@
+import { Deprecation } from "deprecation";
+
+import { getNodeMiddleware, App } from "../src";
+
+describe("deprecations", () => {
+  test("getNodeMiddleware() - #263", async () => {
+    const warn = jest.fn();
+    const app = new App({
+      appId: "123",
+      privateKey: "privateKey",
+      oauth: {
+        clientId: "123",
+        clientSecret: "123secret",
+      },
+      webhooks: {
+        secret: "secret",
+      },
+      // @ts-expect-error
+      log: { warn },
+    });
+
+    getNodeMiddleware(app);
+
+    expect(warn).toBeCalledWith(
+      new Deprecation(
+        "[@octokit/app] getNodeMiddleware is deprecated. Use createNodeMiddleware instead"
+      )
+    );
+  });
+});

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { App, getNodeMiddleware } from "../src";
+import { App, createNodeMiddleware } from "../src";
 
 describe("smoke", () => {
   it("App", () => {
@@ -23,7 +23,7 @@ describe("smoke", () => {
     expect(App.VERSION).toEqual("0.0.0-development");
   });
 
-  it("getNodeMiddleware", () => {
-    expect(typeof getNodeMiddleware).toBe("function");
+  it("createNodeMiddleware", () => {
+    expect(typeof createNodeMiddleware).toBe("function");
   });
 });


### PR DESCRIPTION
fixes #205


-----
[View rendered README.md](https://github.com/octokit/app.js/blob/205/createNodeMiddleware/README.md)