### PR TITLE
feat: v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1925,20 +1925,20 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "9.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.0.0-beta.5.tgz",
-      "integrity": "sha512-5Z2i1O4cnOq2mgevjCK/VO2YAXFsX4vsuQCRHTClVrefBk7sGPQqNc4vhKFrFbZMHooJv2u0jMvMbyS3AxTPHg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.0.0.tgz",
+      "integrity": "sha512-r8ZTnYAOZydrhRMnDonAVdeOl4IhK144UD+Vw8GUZCHurZxwO88VhoxV02omz2dm41h07EDo77i4H/A1DZ+0LQ==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
-        "@octokit/webhooks-definitions": "3.65.5",
+        "@octokit/webhooks-definitions": "3.67.3",
         "@octokit/webhooks-methods": "^1.0.0",
         "aggregate-error": "^3.1.0"
       }
     },
     "@octokit/webhooks-definitions": {
-      "version": "3.65.5",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.65.5.tgz",
-      "integrity": "sha512-cQxHFYIrOHINEaw/dE8qrZKCmrJ7h8OOj8ZKeMq9KtP9ueBr9VdHKddbG4OMYEVHtylGSlGsvYT6GZBPYJe8OQ=="
+      "version": "3.67.3",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.67.3.tgz",
+      "integrity": "sha512-do4Z1r2OVhuI0ihJhQ8Hg+yPWnBYEBNuFNCrvtPKoYT1w81jD7pBXgGe86lYuuNirkDHb0Nxt+zt4O5GiFJfgA=="
     },
     "@octokit/webhooks-methods": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1925,12 +1925,13 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "9.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.0.0-beta.3.tgz",
-      "integrity": "sha512-ln0zgS0iTYAHjat5cnMfiHfn0L0Rt3FDLIb0EeMfuhBKJHq9NWfKpzm/sy2NfZQ3cZFS0bWFQZAceD9ZkNA3Ng==",
+      "version": "9.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.0.0-beta.5.tgz",
+      "integrity": "sha512-5Z2i1O4cnOq2mgevjCK/VO2YAXFsX4vsuQCRHTClVrefBk7sGPQqNc4vhKFrFbZMHooJv2u0jMvMbyS3AxTPHg==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-definitions": "3.65.5",
+        "@octokit/webhooks-methods": "^1.0.0",
         "aggregate-error": "^3.1.0"
       }
     },
@@ -1938,6 +1939,11 @@
       "version": "3.65.5",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.65.5.tgz",
       "integrity": "sha512-cQxHFYIrOHINEaw/dE8qrZKCmrJ7h8OOj8ZKeMq9KtP9ueBr9VdHKddbG4OMYEVHtylGSlGsvYT6GZBPYJe8OQ=="
+    },
+    "@octokit/webhooks-methods": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-1.0.0.tgz",
+      "integrity": "sha512-pVceMQcj9SZ5p2RkemL0TuuPdGULNQj9F3Pq1cNM1xH+Kst1VNt0dj3PEGZRZV473njrDnYdi/OG4wWY9TLbbA=="
     },
     "@pika/babel-plugin-esm-import-rewrite": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@octokit/oauth-app": "^3.2.0",
     "@octokit/plugin-paginate-rest": "^2.6.0",
     "@octokit/types": "^6.0.3",
-    "@octokit/webhooks": "^9.0.0-beta.5"
+    "@octokit/webhooks": "^9.0.0"
   },
   "devDependencies": {
     "@pika/pack": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@octokit/oauth-app": "^3.2.0",
     "@octokit/plugin-paginate-rest": "^2.6.0",
     "@octokit/types": "^6.0.3",
-    "@octokit/webhooks": "^9.0.0-beta.3"
+    "@octokit/webhooks": "^9.0.0-beta.5"
   },
   "devDependencies": {
     "@pika/pack": "^0.5.0",

--- a/test/readme-examples.test.ts
+++ b/test/readme-examples.test.ts
@@ -241,7 +241,7 @@ describe("README examples", () => {
       headers: {
         "x-github-event": "issues",
         "x-github-delivery": "event-id-123",
-        "x-hub-signature-256": app.webhooks.sign(data),
+        "x-hub-signature-256": await app.webhooks.sign(data),
       },
       data,
     }).catch(console.error);


### PR DESCRIPTION
Blocked by https://github.com/octokit/webhooks.js/pull/518

### Breaking changes

- default `sign` algorithm for `app.webhooks.sign` is now `sha256`. Use `app.webhooks.sign({ algorithm: "sha1", secret }, payload)` to fall back to `sha1`.
- `app.webhooks.sign()` and `app.webhooks.verify()` are now asynchronous