### PR TITLE
fix: remove type imports from "http" for Deno compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,9 +1819,9 @@
       }
     },
     "@octokit/oauth-app": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-3.3.1.tgz",
-      "integrity": "sha512-gpOxl89VfNGPvEvbsRNY6KyvFzeYEHc6ALCoCAsQKekOt/dU4wF3+6ct6NBi1cPMxp/NS49DEhLL3+BDlIvObw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-3.3.2.tgz",
+      "integrity": "sha512-vZPleCS65Sq2fXQYWt1JmTqrNUdsmdvmgr4rmZhxKaX/Fc6xExtNCBmksAbSMY9q3uFBv76BuvNWGKFNpXy5Tw==",
       "requires": {
         "@octokit/auth-oauth-app": "^4.0.0",
         "@octokit/auth-oauth-user": "^1.2.3",
@@ -1923,9 +1923,9 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.0.0.tgz",
-      "integrity": "sha512-r8ZTnYAOZydrhRMnDonAVdeOl4IhK144UD+Vw8GUZCHurZxwO88VhoxV02omz2dm41h07EDo77i4H/A1DZ+0LQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.0.1.tgz",
+      "integrity": "sha512-t7dRsS97fRN5V9kqh2UpRPheRWTgbgzUOJju0fttVKrEjkdbKyTNV3U/AoK9FyKz2wABr3uBIUM9sFfNxCcw/Q==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-definitions": "3.67.3",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "dependencies": {
     "@octokit/auth-app": "^3.3.0",
     "@octokit/auth-unauthenticated": "^2.0.4",
-    "@octokit/core": "^3.2.0",
-    "@octokit/oauth-app": "^3.2.0",
-    "@octokit/plugin-paginate-rest": "^2.6.0",
-    "@octokit/types": "^6.0.3",
-    "@octokit/webhooks": "^9.0.0"
+    "@octokit/core": "^3.4.0",
+    "@octokit/oauth-app": "^3.3.2",
+    "@octokit/plugin-paginate-rest": "^2.13.3",
+    "@octokit/types": "^6.13.0",
+    "@octokit/webhooks": "^9.0.1"
   },
   "devDependencies": {
     "@pika/pack": "^0.5.0",

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -1,4 +1,8 @@
-import { IncomingMessage, ServerResponse } from "http";
+// remove type imports from http for Deno compatibility
+// see https://github.com/octokit/octokit.js/issues/24#issuecomment-817361886
+// import { IncomingMessage, ServerResponse } from "http";
+type IncomingMessage = any;
+type ServerResponse = any;
 
 import { createNodeMiddleware as oauthNodeMiddleware } from "@octokit/oauth-app";
 import { createNodeMiddleware as webhooksNodeMiddleware } from "@octokit/webhooks";

--- a/src/middleware/node/on-unhandled-request-default.ts
+++ b/src/middleware/node/on-unhandled-request-default.ts
@@ -1,4 +1,8 @@
-import { IncomingMessage, ServerResponse } from "http";
+// remove type imports from http for Deno compatibility
+// see https://github.com/octokit/octokit.js/issues/24#issuecomment-817361886
+// import { IncomingMessage, ServerResponse } from "http";
+type IncomingMessage = any;
+type ServerResponse = any;
 
 export function onUnhandledRequestDefault(
   request: IncomingMessage,


### PR DESCRIPTION
Fixes #230.

I see also two imports 

```typescript
import { createServer } from "http";
```

Not sure if I need to do anything about them or it's just about types.