### PR TITLE
fix(typescript): avoid `import { App } from "../...d.ts"` in types export

### DIFF
--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -7,7 +7,7 @@ type ServerResponse = any;
 import { createNodeMiddleware as oauthNodeMiddleware } from "@octokit/oauth-app";
 import { createNodeMiddleware as webhooksNodeMiddleware } from "@octokit/webhooks";
 
-import { App } from "../..";
+import { App } from "../../index";
 import { onUnhandledRequestDefault } from "./on-unhandled-request-default";
 import { Options } from "../../types";
 


### PR DESCRIPTION
see https://cdn.skypack.dev/-/@octokit/app@v12.0.1-kdfMCfq9xqcmWHFjAsTl/dist=es2020,mode=types/dist-types/middleware/node/index.d.ts. Part of resolving https://github.com/octokit/octokit.js/issues/24