### PR TITLE
fix: revert dependency on `@octokit/webhooks` to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/oauth-app": "^3.3.2",
         "@octokit/plugin-paginate-rest": "^2.13.3",
         "@octokit/types": "^6.27.1",
-        "@octokit/webhooks": "^10.0.0"
+        "@octokit/webhooks": "^9.0.1"
       },
       "devDependencies": {
         "@pika/pack": "^0.5.0",
@@ -2548,17 +2548,14 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-10.0.0.tgz",
-      "integrity": "sha512-5twwJ5UZ4nwTyEsue4bsrbiehSK/vSKqH9GP1d3AJkCygpjDZc0w/glL+ldhRhisoqCcADmyy7Xj2NuvBlVXRg==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.16.0.tgz",
+      "integrity": "sha512-SITUlQUpnuv3XvDNmU31Sk6gyw87UMwmY15PFmBduQtsJ98tb+z/UwvPeepD4XFfZA3JvGwprtY4eUJSkWbmEw==",
       "dependencies": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-methods": "^2.0.0",
-        "@octokit/webhooks-types": "5.8.0",
+        "@octokit/webhooks-types": "4.10.0",
         "aggregate-error": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@octokit/webhooks-methods": {
@@ -2567,9 +2564,9 @@
       "integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig=="
     },
     "node_modules/@octokit/webhooks-types": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
-      "integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw=="
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.10.0.tgz",
+      "integrity": "sha512-3x4OsnsGKs77zBQlzZjcgdSVRFhw+x+Tt7gt1dtKakKjzwa6NtI8n9m/IB1vR+v8Km1qrN+S26IHYj20IQlFdg=="
     },
     "node_modules/@pika/babel-plugin-esm-import-rewrite": {
       "version": "0.6.1",
@@ -12939,13 +12936,13 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-10.0.0.tgz",
-      "integrity": "sha512-5twwJ5UZ4nwTyEsue4bsrbiehSK/vSKqH9GP1d3AJkCygpjDZc0w/glL+ldhRhisoqCcADmyy7Xj2NuvBlVXRg==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.16.0.tgz",
+      "integrity": "sha512-SITUlQUpnuv3XvDNmU31Sk6gyw87UMwmY15PFmBduQtsJ98tb+z/UwvPeepD4XFfZA3JvGwprtY4eUJSkWbmEw==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-methods": "^2.0.0",
-        "@octokit/webhooks-types": "5.8.0",
+        "@octokit/webhooks-types": "4.10.0",
         "aggregate-error": "^3.1.0"
       }
     },
@@ -12955,9 +12952,9 @@
       "integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig=="
     },
     "@octokit/webhooks-types": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
-      "integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw=="
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.10.0.tgz",
+      "integrity": "sha512-3x4OsnsGKs77zBQlzZjcgdSVRFhw+x+Tt7gt1dtKakKjzwa6NtI8n9m/IB1vR+v8Km1qrN+S26IHYj20IQlFdg=="
     },
     "@pika/babel-plugin-esm-import-rewrite": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@octokit/oauth-app": "^3.3.2",
     "@octokit/plugin-paginate-rest": "^2.13.3",
     "@octokit/types": "^6.27.1",
-    "@octokit/webhooks": "^10.0.0"
+    "@octokit/webhooks": "^9.0.1"
   },
   "devDependencies": {
     "@pika/pack": "^0.5.0",


### PR DESCRIPTION
`@octokit/webhooks` dropped compatibility with NodeJS v10 and v12 (octokit/webhooks.js#555), and it was merged into this repo, without creating a new major release.

This reverts commit 635708c827720614bf5fecc95bdafeb1170d38ec.