### PR TITLE
ci: stop testing NodeJS v12, start testing v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 12
           - 14
           - 16
+          - 18
     steps:
       - uses: actions/checkout@v3
       - name: "Use Node.js ${{ matrix.node_version }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,9 @@
         "semantic-release-plugin-update-version-in-files": "^1.0.0",
         "ts-jest": "^28.0.0",
         "typescript": "^4.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "ts-jest": "^28.0.0",
     "typescript": "^4.0.5"
   },
+  "engines": {
+    "node": ">= 14"
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
@@ -61,7 +64,10 @@
         "@pika/plugin-ts-standard-pkg"
       ],
       [
-        "@pika/plugin-build-node"
+        "@pika/plugin-build-node",
+        {
+          "minNodeVersion": "14"
+        }
       ]
     ]
   },


### PR DESCRIPTION
BREAKING CHANGES: Drop support for NodeJS v10, v12

#288 removed NodeJS v10 without releasing a major version