### PR TITLE
fix: github api does not need `state` when creating a token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/auth-app": "^4.0.0",
         "@octokit/auth-unauthenticated": "^3.0.0",
         "@octokit/core": "^4.0.0",
-        "@octokit/oauth-app": "^3.3.2",
+        "@octokit/oauth-app": "^4.0.4",
         "@octokit/plugin-paginate-rest": "^2.13.3",
         "@octokit/types": "^6.27.1",
         "@octokit/webhooks": "^10.0.0"
@@ -2557,50 +2557,120 @@
       }
     },
     "node_modules/@octokit/oauth-app": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-3.6.0.tgz",
-      "integrity": "sha512-OxPw4ItQXaC2GuEXyZB7EmZ2rHvNFX4y3yAsqdFIRW7qg2HyoEPxacxza6c8wqbEEvu84b98AJ5BXm+IjPWrww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-4.0.4.tgz",
+      "integrity": "sha512-9uFcgC+jqD48XVnx0ftx+YE3sknR3kzD8J5Gn7zmlnWqKMfxBgHxtvfcoGkcOSuHf6sYpbgDnI0dk6JlOtirLA==",
       "dependencies": {
         "@octokit/auth-oauth-app": "^4.0.0",
-        "@octokit/auth-oauth-user": "^1.3.0",
-        "@octokit/auth-unauthenticated": "^2.0.0",
-        "@octokit/core": "^3.3.2",
+        "@octokit/auth-oauth-user": "^2.0.0",
+        "@octokit/auth-unauthenticated": "^3.0.0",
+        "@octokit/core": "^4.0.0",
         "@octokit/oauth-authorization-url": "^4.2.1",
-        "@octokit/oauth-methods": "^1.2.2",
+        "@octokit/oauth-methods": "^2.0.0",
         "@types/aws-lambda": "^8.10.83",
         "fromentries": "^1.3.1",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "optionalDependencies": {
+        "aws-lambda": "^1.0.7"
       }
     },
-    "node_modules/@octokit/oauth-app/node_modules/@octokit/auth-token": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+    "node_modules/@octokit/oauth-app/node_modules/@octokit/auth-oauth-user": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-2.0.0.tgz",
+      "integrity": "sha512-rrXWR2jdM9HwrM8C5ozGt8oz6rOK5MI/dNEUQ7uUusXBAvnTqRpT9DZ8ekFZKTe8U0dAKq+382NWiZX26rx1kw==",
       "dependencies": {
-        "@octokit/types": "^6.0.3"
-      }
-    },
-    "node_modules/@octokit/oauth-app/node_modules/@octokit/auth-unauthenticated": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-2.1.0.tgz",
-      "integrity": "sha512-+baofLfSL0CAv3CfGQ9rxiZZQEX8VNJMGuuS4PgrMRBUL52Ho5+hQYb63UJQshw7EXYMPDZxbXznc0y33cbPqw==",
-      "dependencies": {
-        "@octokit/request-error": "^2.1.0",
-        "@octokit/types": "^6.0.3"
-      }
-    },
-    "node_modules/@octokit/oauth-app/node_modules/@octokit/core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
-      "dependencies": {
-        "@octokit/auth-token": "^2.4.4",
-        "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.3",
-        "@octokit/request-error": "^2.0.5",
-        "@octokit/types": "^6.0.3",
-        "before-after-hook": "^2.2.0",
+        "@octokit/auth-oauth-device": "^3.1.1",
+        "@octokit/oauth-methods": "^1.1.0",
+        "@octokit/request": "^6.0.0",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/oauth-app/node_modules/@octokit/auth-oauth-user/node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/oauth-app/node_modules/@octokit/auth-oauth-user/node_modules/@octokit/oauth-methods": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-1.2.6.tgz",
+      "integrity": "sha512-nImHQoOtKnSNn05uk2o76om1tJWiAo4lOu2xMAHYsNr0fwopP+Dv+2MlGvaMMlFjoqVd3fF3X5ZDTKCsqgmUaQ==",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^4.3.1",
+        "@octokit/request": "^5.4.14",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0"
+      }
+    },
+    "node_modules/@octokit/oauth-app/node_modules/@octokit/auth-oauth-user/node_modules/@octokit/oauth-methods/node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/oauth-app/node_modules/@octokit/endpoint": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.0.tgz",
+      "integrity": "sha512-Kz/mIkOTjs9rV50hf/JK9pIDl4aGwAtT8pry6Rpy+hVXkAPhXanNQRxMoq6AeRgDCZR6t/A1zKniY2V1YhrzlQ==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/oauth-app/node_modules/@octokit/oauth-methods": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-2.0.1.tgz",
+      "integrity": "sha512-CCmYPNAp4Xz0Ja38+xx6Kigr2zhBkTOjo36eUI+xw8P07K1LY/XSep+mLyOmx9Bu2Q9O06cN2rPJCKmp1y1+bg==",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^4.3.1",
+        "@octokit/request": "^6.0.0",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/oauth-app/node_modules/@octokit/request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.0.1.tgz",
+      "integrity": "sha512-9DSQ7fKBeSMU5aD6JfWA/1XFwP44X32d9fSYdQzxSsROjOginPYtW4Xwwt3Qs7wZtBmFOWV/td3gxOHmz9hfig==",
+      "dependencies": {
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@octokit/oauth-authorization-url": {
@@ -3155,7 +3225,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -3219,6 +3289,57 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "node_modules/aws-lambda": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
+      "integrity": "sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==",
+      "optional": true,
+      "dependencies": {
+        "aws-sdk": "^2.814.0",
+        "commander": "^3.0.2",
+        "js-yaml": "^3.14.1",
+        "watchpack": "^2.0.0-beta.10"
+      },
+      "bin": {
+        "lambda": "bin/lambda"
+      }
+    },
+    "node_modules/aws-lambda/node_modules/commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+      "optional": true
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1170.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1170.0.tgz",
+      "integrity": "sha512-0hbXILJ6EvLJk9cBqkPwgXu+RLZ1B5lK3RyCh56oKbr+uIu4pXlqhj3CH9QVvWji8dmvn5/W5n+Sifnl8ISrOA==",
+      "optional": true,
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "8.0.0",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
     },
     "node_modules/babel-jest": {
       "version": "28.1.1",
@@ -3444,6 +3565,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -3612,6 +3753,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -4564,7 +4716,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -4595,6 +4747,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/execa": {
@@ -5008,7 +5169,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/global-dirs": {
       "version": "2.1.0",
@@ -5097,7 +5258,7 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -5228,6 +5389,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "optional": true
     },
     "node_modules/import-fresh": {
       "version": "2.0.0",
@@ -5871,6 +6038,12 @@
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "optional": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -7678,6 +7851,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7688,7 +7870,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -9921,6 +10103,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "optional": true
+    },
     "node_modules/scoped-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-2.1.0.tgz",
@@ -10154,7 +10342,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -10905,6 +11093,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "optional": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -10930,6 +11128,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "optional": true
+    },
+    "node_modules/url/node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -10937,6 +11151,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -10988,6 +11211,19 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "optional": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/whatwg-url": {
@@ -11158,6 +11394,25 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "optional": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {
@@ -13045,49 +13300,106 @@
       }
     },
     "@octokit/oauth-app": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-3.6.0.tgz",
-      "integrity": "sha512-OxPw4ItQXaC2GuEXyZB7EmZ2rHvNFX4y3yAsqdFIRW7qg2HyoEPxacxza6c8wqbEEvu84b98AJ5BXm+IjPWrww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-4.0.4.tgz",
+      "integrity": "sha512-9uFcgC+jqD48XVnx0ftx+YE3sknR3kzD8J5Gn7zmlnWqKMfxBgHxtvfcoGkcOSuHf6sYpbgDnI0dk6JlOtirLA==",
       "requires": {
         "@octokit/auth-oauth-app": "^4.0.0",
-        "@octokit/auth-oauth-user": "^1.3.0",
-        "@octokit/auth-unauthenticated": "^2.0.0",
-        "@octokit/core": "^3.3.2",
+        "@octokit/auth-oauth-user": "^2.0.0",
+        "@octokit/auth-unauthenticated": "^3.0.0",
+        "@octokit/core": "^4.0.0",
         "@octokit/oauth-authorization-url": "^4.2.1",
-        "@octokit/oauth-methods": "^1.2.2",
+        "@octokit/oauth-methods": "^2.0.0",
         "@types/aws-lambda": "^8.10.83",
+        "aws-lambda": "^1.0.7",
         "fromentries": "^1.3.1",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
-        "@octokit/auth-token": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-          "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+        "@octokit/auth-oauth-user": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-2.0.0.tgz",
+          "integrity": "sha512-rrXWR2jdM9HwrM8C5ozGt8oz6rOK5MI/dNEUQ7uUusXBAvnTqRpT9DZ8ekFZKTe8U0dAKq+382NWiZX26rx1kw==",
           "requires": {
-            "@octokit/types": "^6.0.3"
+            "@octokit/auth-oauth-device": "^3.1.1",
+            "@octokit/oauth-methods": "^1.1.0",
+            "@octokit/request": "^6.0.0",
+            "@octokit/types": "^6.12.2",
+            "btoa-lite": "^1.0.0",
+            "universal-user-agent": "^6.0.0"
+          },
+          "dependencies": {
+            "@octokit/endpoint": {
+              "version": "6.0.12",
+              "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+              "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+              "requires": {
+                "@octokit/types": "^6.0.3",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+              }
+            },
+            "@octokit/oauth-methods": {
+              "version": "1.2.6",
+              "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-1.2.6.tgz",
+              "integrity": "sha512-nImHQoOtKnSNn05uk2o76om1tJWiAo4lOu2xMAHYsNr0fwopP+Dv+2MlGvaMMlFjoqVd3fF3X5ZDTKCsqgmUaQ==",
+              "requires": {
+                "@octokit/oauth-authorization-url": "^4.3.1",
+                "@octokit/request": "^5.4.14",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.12.2",
+                "btoa-lite": "^1.0.0"
+              },
+              "dependencies": {
+                "@octokit/request": {
+                  "version": "5.6.3",
+                  "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+                  "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+                  "requires": {
+                    "@octokit/endpoint": "^6.0.1",
+                    "@octokit/request-error": "^2.1.0",
+                    "@octokit/types": "^6.16.1",
+                    "is-plain-object": "^5.0.0",
+                    "node-fetch": "^2.6.7",
+                    "universal-user-agent": "^6.0.0"
+                  }
+                }
+              }
+            }
           }
         },
-        "@octokit/auth-unauthenticated": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-2.1.0.tgz",
-          "integrity": "sha512-+baofLfSL0CAv3CfGQ9rxiZZQEX8VNJMGuuS4PgrMRBUL52Ho5+hQYb63UJQshw7EXYMPDZxbXznc0y33cbPqw==",
+        "@octokit/endpoint": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.0.tgz",
+          "integrity": "sha512-Kz/mIkOTjs9rV50hf/JK9pIDl4aGwAtT8pry6Rpy+hVXkAPhXanNQRxMoq6AeRgDCZR6t/A1zKniY2V1YhrzlQ==",
           "requires": {
-            "@octokit/request-error": "^2.1.0",
-            "@octokit/types": "^6.0.3"
-          }
-        },
-        "@octokit/core": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-          "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
-          "requires": {
-            "@octokit/auth-token": "^2.4.4",
-            "@octokit/graphql": "^4.5.8",
-            "@octokit/request": "^5.6.3",
-            "@octokit/request-error": "^2.0.5",
             "@octokit/types": "^6.0.3",
-            "before-after-hook": "^2.2.0",
+            "is-plain-object": "^5.0.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/oauth-methods": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-2.0.1.tgz",
+          "integrity": "sha512-CCmYPNAp4Xz0Ja38+xx6Kigr2zhBkTOjo36eUI+xw8P07K1LY/XSep+mLyOmx9Bu2Q9O06cN2rPJCKmp1y1+bg==",
+          "requires": {
+            "@octokit/oauth-authorization-url": "^4.3.1",
+            "@octokit/request": "^6.0.0",
+            "@octokit/request-error": "^2.0.5",
+            "@octokit/types": "^6.12.2",
+            "btoa-lite": "^1.0.0"
+          }
+        },
+        "@octokit/request": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.0.1.tgz",
+          "integrity": "sha512-9DSQ7fKBeSMU5aD6JfWA/1XFwP44X32d9fSYdQzxSsROjOginPYtW4Xwwt3Qs7wZtBmFOWV/td3gxOHmz9hfig==",
+          "requires": {
+            "@octokit/endpoint": "^7.0.0",
+            "@octokit/request-error": "^2.1.0",
+            "@octokit/types": "^6.16.1",
+            "is-plain-object": "^5.0.0",
+            "node-fetch": "^2.6.7",
             "universal-user-agent": "^6.0.0"
           }
         }
@@ -13581,7 +13893,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -13630,6 +13942,51 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "aws-lambda": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
+      "integrity": "sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==",
+      "optional": true,
+      "requires": {
+        "aws-sdk": "^2.814.0",
+        "commander": "^3.0.2",
+        "js-yaml": "^3.14.1",
+        "watchpack": "^2.0.0-beta.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+          "optional": true
+        }
+      }
+    },
+    "aws-sdk": {
+      "version": "2.1170.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1170.0.tgz",
+      "integrity": "sha512-0hbXILJ6EvLJk9cBqkPwgXu+RLZ1B5lK3RyCh56oKbr+uIu4pXlqhj3CH9QVvWji8dmvn5/W5n+Sifnl8ISrOA==",
+      "optional": true,
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "8.0.0",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+          "optional": true
+        }
+      }
     },
     "babel-jest": {
       "version": "28.1.1",
@@ -13806,6 +14163,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "optional": true
+    },
     "before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -13947,6 +14310,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "optional": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -14692,7 +15066,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "devOptional": true
     },
     "estree-walker": {
       "version": "0.6.1",
@@ -14711,6 +15085,12 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "optional": true
     },
     "execa": {
       "version": "2.1.0",
@@ -15030,7 +15410,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
+      "devOptional": true
     },
     "global-dirs": {
       "version": "2.1.0",
@@ -15102,7 +15482,7 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "devOptional": true
     },
     "has": {
       "version": "1.0.3",
@@ -15204,6 +15584,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "optional": true
     },
     "import-fresh": {
       "version": "2.0.0",
@@ -15692,6 +16078,12 @@
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "optional": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -17030,6 +17422,12 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "optional": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17040,7 +17438,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -18769,6 +19167,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "optional": true
+    },
     "scoped-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-2.1.0.tgz",
@@ -18969,7 +19373,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "devOptional": true
     },
     "stack-utils": {
       "version": "2.0.5",
@@ -19532,6 +19936,30 @@
         }
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "optional": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+          "optional": true
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+          "optional": true
+        }
+      }
+    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -19556,6 +19984,12 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
+    },
+    "uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "optional": true
     },
     "v8-to-istanbul": {
       "version": "9.0.1",
@@ -19600,6 +20034,16 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "optional": true,
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
       }
     },
     "whatwg-url": {
@@ -19735,6 +20179,22 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "optional": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "optional": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@octokit/auth-app": "^4.0.0",
     "@octokit/auth-unauthenticated": "^3.0.0",
     "@octokit/core": "^4.0.0",
-    "@octokit/oauth-app": "^3.3.2",
+    "@octokit/oauth-app": "^4.0.4",
     "@octokit/plugin-paginate-rest": "^2.13.3",
     "@octokit/types": "^6.27.1",
     "@octokit/webhooks": "^10.0.0"

--- a/test/readme-examples.test.ts
+++ b/test/readme-examples.test.ts
@@ -267,7 +267,6 @@ describe("README examples", () => {
             client_id: CLIENT_ID,
             client_secret: CLIENT_SECRET,
             code: "code123",
-            state: "state123",
           },
         }
       )


### PR DESCRIPTION
The `POST https://github.com/login/oauth/access_token` endpoint is documented as accepting an optional `state` parameter in the [GitHub App section](https://docs.github.com/en/developers/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps#2-users-are-redirected-back-to-your-site-by-github) but not in the [OAuth App section](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github).

`state` is designed to let front-end code differentiate valid authorizations from forged attacks:

> `state` is a random string to protect against forgery attacks and could contain any other arbitrary data.

> If the user accepts your request, GitHub redirects back to your site with a temporary code in a code parameter as well as the state you provided in the previous step in a state parameter. If the states don't match, the request was created by a third party and the process should be aborted.

I’ve tested that the `POST https://github.com/login/oauth/access_token` endpoint ignores `state` even for GitHub App:

- one can create a token without a `state` parameter
- passing a random state (different from the state used to generate the code) from `oauth-app.js` to `octokit/core` does not prevent creating a valid token

I’m not a security guru and my tests may be flawed. Please let me know if that’s not the case.
