### PR TITLE
feat: (unstable) set `x-github-delivery` header on requests sent in response to webhook event

### DIFF
--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -27,7 +27,7 @@ export function webhooks(
 
         return {
           ...event,
-          octokit: octokit,
+          octokit,
         };
       }
 
@@ -49,9 +49,19 @@ export function webhooks(
         },
       })) as Octokit;
 
+      // set `x-github-delivery` header on all requests sent in response to the current
+      // event. This allows GitHub Support to correlate the request with the event.
+      // This is not documented and not considered public API, the header may change.
+      // Once we document this as best practice on https://docs.github.com/en/rest/guides/best-practices-for-integrators
+      // we will make it official
+      /* istanbul ignore next */
+      octokit.hook.before("request", (options) => {
+        options.headers["x-github-delivery"] = event.id;
+      });
+
       return {
         ...event,
-        octokit: octokit,
+        octokit,
       };
     },
   });


### PR DESCRIPTION
## Behavior

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- no previous behavior is changed

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- all requests sent using the `octokit` instance passed to an `octokit.webhooks.on(eventName, callback)` callback will now set a `set-x-github-delivery-header` header to the webhook event's delivery GUID.

### Other information

<!-- Any other information that is important to this PR  -->

- I would like to enventually add this as best practice to https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28. We discussed it in the past but it was never a high priority. Setting the header basically allows GitHub Support to trace a request back to the webhook event that triggered it, and what other requests have been sent in response to the same webhook event.

  But until it's official, I would consider this an unstable feature. I'd like to add it as I'm working on some webhooks tooling where this would come in very handy, and there is no simple workaround other than manually setting the header on all requests in all webhook event handlers.

## Additional info

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

- N/A

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:

- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

---
