### PR TITLE
fix: update for the handling of an error being thrown by the verify method in webhooks.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/oauth-app": "^6.0.0",
         "@octokit/plugin-paginate-rest": "^9.0.0",
         "@octokit/types": "^12.0.0",
-        "@octokit/webhooks": "^12.0.1"
+        "@octokit/webhooks": "^12.0.4"
       },
       "devDependencies": {
         "@octokit/tsconfig": "^2.0.0",
@@ -1982,9 +1982,9 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.0.3.tgz",
-      "integrity": "sha512-8iG+/yza7hwz1RrQ7i7uGpK2/tuItZxZq1aTmeg2TNp2xTUB8F8lZF/FcZvyyAxT8tpDMF74TjFGCDACkf1kAQ==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.0.4.tgz",
+      "integrity": "sha512-dopyfA1suemLwlJsiEBKEW7hnVrxvk2xzXHkUkx68vl74ie9JzdizW6FUU0gVi3Bq3AVrIXS1Yt4vCF4KV5pqA==",
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
         "@octokit/webhooks-methods": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@octokit/oauth-app": "^6.0.0",
     "@octokit/plugin-paginate-rest": "^9.0.0",
     "@octokit/types": "^12.0.0",
-    "@octokit/webhooks": "^12.0.1"
+    "@octokit/webhooks": "^12.0.4"
   },
   "devDependencies": {
     "@octokit/tsconfig": "^2.0.0",


### PR DESCRIPTION
Relates to:
* https://github.com/octokit/webhooks.js/pull/914
* https://github.com/octokit/webhooks.js/pull/915
* https://github.com/octokit/webhooks.js/pull/916
* https://github.com/octokit/webhooks.js/pull/917

Fixes an issue where webhooks.js was throwing an error which could cause downstream problems.