### PR TITLE
refactor: use `node:` specifier imports and full relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "ipaddr.js": "<rootDir>/node_modules/ipaddr.js/lib/ipaddr.js",
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "prettier --write {src,test}/* *.md package.json",
     "pretest": "npm run -s lint",
     "test": "jest --coverage",
-    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --esModuleInterop --strict --target es2020 --moduleResolution node test/typescript-validate.ts"
+    "test:typescript": "npx tsc --allowImportingTsExtensions --noEmit --declaration --noUnusedLocals --esModuleInterop --strict --target es2020 --moduleResolution node16 --module node16 test/typescript-validate.ts"
   },
   "repository": "github:octokit/app.js",
   "author": "Gregor Martynus (https://github.com/gr2m)",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 /**

--- a/src/each-installation.ts
+++ b/src/each-installation.ts
@@ -1,12 +1,12 @@
 import { composePaginateRest } from "@octokit/plugin-paginate-rest";
 import { Octokit } from "@octokit/core";
 
-import { App } from "./index";
+import type { App } from "./index.js";
 import type {
   EachInstallationFunction,
   EachInstallationInterface,
-} from "./types";
-import { getInstallationOctokit } from "./get-installation-octokit";
+} from "./types.js";
+import { getInstallationOctokit } from "./get-installation-octokit.js";
 
 export function eachInstallationFactory(app: App) {
   return Object.assign(eachInstallation.bind(null, app), {

--- a/src/each-installation.ts
+++ b/src/each-installation.ts
@@ -1,5 +1,5 @@
 import { composePaginateRest } from "@octokit/plugin-paginate-rest";
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 
 import type { App } from "./index.js";
 import type {

--- a/src/each-repository.ts
+++ b/src/each-repository.ts
@@ -1,12 +1,12 @@
 import { composePaginateRest } from "@octokit/plugin-paginate-rest";
 import { Octokit } from "@octokit/core";
 
-import { App } from "./index";
+import type { App } from "./index.js";
 import type {
   EachRepositoryFunction,
   EachRepositoryInterface,
   EachRepositoryQuery,
-} from "./types";
+} from "./types.js";
 
 export function eachRepositoryFactory(app: App) {
   return Object.assign(eachRepository.bind(null, app), {

--- a/src/each-repository.ts
+++ b/src/each-repository.ts
@@ -1,5 +1,5 @@
 import { composePaginateRest } from "@octokit/plugin-paginate-rest";
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 
 import type { App } from "./index.js";
 import type {

--- a/src/get-installation-octokit.ts
+++ b/src/get-installation-octokit.ts
@@ -1,7 +1,7 @@
 import { createAppAuth } from "@octokit/auth-app";
 import { Octokit } from "@octokit/core";
 
-import { App } from "./index";
+import type { App } from "./index.js";
 
 export async function getInstallationOctokit(app: App, installationId: number) {
   return app.octokit.auth({

--- a/src/get-installation-octokit.ts
+++ b/src/get-installation-octokit.ts
@@ -1,5 +1,5 @@
 import { createAppAuth } from "@octokit/auth-app";
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 
 import type { App } from "./index.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Octokit as OctokitCore } from "@octokit/core";
 import { createAppAuth } from "@octokit/auth-app";
 import { OAuthApp } from "@octokit/oauth-app";
-import { Webhooks } from "@octokit/webhooks";
+import type { Webhooks } from "@octokit/webhooks";
 
 import type {
   Options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,4 +143,4 @@ export class App<TOptions extends Options = Options> {
   }
 }
 
-export { createNodeMiddleware } from "./middleware/node/index";
+export { createNodeMiddleware } from "./middleware/node/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,12 @@ import type {
   EachInstallationInterface,
   EachRepositoryInterface,
   GetInstallationOctokitInterface,
-} from "./types";
-import { VERSION } from "./version";
-import { webhooks } from "./webhooks";
-import { eachInstallationFactory } from "./each-installation";
-import { eachRepositoryFactory } from "./each-repository";
-import { getInstallationOctokit } from "./get-installation-octokit";
+} from "./types.js";
+import { VERSION } from "./version.js";
+import { webhooks } from "./webhooks.js";
+import { eachInstallationFactory } from "./each-installation.js";
+import { eachRepositoryFactory } from "./each-repository.js";
+import { getInstallationOctokit } from "./get-installation-octokit.js";
 
 type Constructor<T> = new (...args: any[]) => T;
 

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -1,6 +1,6 @@
 // remove type imports from http for Deno compatibility
 // see https://github.com/octokit/octokit.js/issues/24#issuecomment-817361886
-// import { IncomingMessage, ServerResponse } from "http";
+// import { IncomingMessage, ServerResponse } from "node:http";
 type IncomingMessage = any;
 type ServerResponse = any;
 

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -11,8 +11,8 @@ import {
 } from "@octokit/oauth-app";
 import { createNodeMiddleware as webhooksNodeMiddleware } from "@octokit/webhooks";
 
-import { App } from "../../index";
-import type { Options } from "../../types";
+import type { App } from "../../index.js";
+import type { Options } from "../../types.js";
 
 export type MiddlewareOptions = {
   pathPrefix?: string;
@@ -23,7 +23,7 @@ function noop() {}
 
 export function createNodeMiddleware(
   app: App,
-  options: MiddlewareOptions = {}
+  options: MiddlewareOptions = {},
 ) {
   const log = Object.assign(
     {
@@ -32,7 +32,7 @@ export function createNodeMiddleware(
       warn: console.warn.bind(console),
       error: console.error.bind(console),
     },
-    options.log
+    options.log,
   );
 
   const optionsWithDefaults = {
@@ -54,7 +54,7 @@ export function createNodeMiddleware(
     null,
     optionsWithDefaults.pathPrefix,
     webhooksMiddleware,
-    oauthMiddleware
+    oauthMiddleware,
   );
 }
 
@@ -64,7 +64,7 @@ export async function middleware(
   oauthMiddleware: any,
   request: IncomingMessage,
   response: ServerResponse,
-  next?: Function
+  next?: Function,
 ): Promise<boolean> {
   const { pathname } = new URL(request.url as string, "http://localhost");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 import type { Endpoints } from "@octokit/types";
 
 export type Options = {

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 import { createAppAuth } from "@octokit/auth-app";
 import { createUnauthenticatedAuth } from "@octokit/auth-unauthenticated";
 import { Webhooks, type EmitterWebhookEvent } from "@octokit/webhooks";

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -3,7 +3,7 @@ import { createAppAuth } from "@octokit/auth-app";
 import { createUnauthenticatedAuth } from "@octokit/auth-unauthenticated";
 import { Webhooks, type EmitterWebhookEvent } from "@octokit/webhooks";
 
-import type { Options } from "./types";
+import type { Options } from "./types.js";
 
 export function webhooks(
   appOctokit: Octokit,

--- a/test/each-installation.test.ts
+++ b/test/each-installation.test.ts
@@ -37,7 +37,7 @@ const WEBHOOK_SECRET = "secret";
 const BEARER =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOi0zMCwiZXhwIjo1NzAsImlzcyI6MX0.q3foRa78U3WegM5PrWLEh5N0bH1SD62OqW66ZYzArp95JBNiCbo8KAlGtiRENCIfBZT9ibDUWy82cI4g3F09mdTq3bD1xLavIfmTksIQCz5EymTWR5v6gL14LSmQdWY9lSqkgUG0XCFljWUglEP39H4yeHbFgdjvAYg3ifDS12z9oQz2ACdSpvxPiTuCC804HkPVw8Qoy0OSXvCkFU70l7VXCVUxnuhHnk8-oCGcKUspmeP6UdDnXk-Aus-eGwDfJbU2WritxxaXw6B4a3flTPojkYLSkPBr6Pi0H2-mBsW_Nvs0aLPVLKobQd4gqTkosX3967DoAG8luUMhrnxe8Q";
 
-import { App } from "../src";
+import { App } from "../src/index.ts";
 
 describe("app.eachInstallation", () => {
   let app: InstanceType<typeof App>;

--- a/test/each-repository.test.ts
+++ b/test/each-repository.test.ts
@@ -37,7 +37,7 @@ const WEBHOOK_SECRET = "secret";
 const BEARER =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOi0zMCwiZXhwIjo1NzAsImlzcyI6MX0.q3foRa78U3WegM5PrWLEh5N0bH1SD62OqW66ZYzArp95JBNiCbo8KAlGtiRENCIfBZT9ibDUWy82cI4g3F09mdTq3bD1xLavIfmTksIQCz5EymTWR5v6gL14LSmQdWY9lSqkgUG0XCFljWUglEP39H4yeHbFgdjvAYg3ifDS12z9oQz2ACdSpvxPiTuCC804HkPVw8Qoy0OSXvCkFU70l7VXCVUxnuhHnk8-oCGcKUspmeP6UdDnXk-Aus-eGwDfJbU2WritxxaXw6B4a3flTPojkYLSkPBr6Pi0H2-mBsW_Nvs0aLPVLKobQd4gqTkosX3967DoAG8luUMhrnxe8Q";
 
-import { App } from "../src";
+import { App } from "../src/index.ts";
 
 describe("app.eachRepository", () => {
   let app: InstanceType<typeof App>;

--- a/test/get-installation-octokit.test.ts
+++ b/test/get-installation-octokit.test.ts
@@ -37,7 +37,7 @@ const WEBHOOK_SECRET = "secret";
 const BEARER =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOi0zMCwiZXhwIjo1NzAsImlzcyI6MX0.q3foRa78U3WegM5PrWLEh5N0bH1SD62OqW66ZYzArp95JBNiCbo8KAlGtiRENCIfBZT9ibDUWy82cI4g3F09mdTq3bD1xLavIfmTksIQCz5EymTWR5v6gL14LSmQdWY9lSqkgUG0XCFljWUglEP39H4yeHbFgdjvAYg3ifDS12z9oQz2ACdSpvxPiTuCC804HkPVw8Qoy0OSXvCkFU70l7VXCVUxnuhHnk8-oCGcKUspmeP6UdDnXk-Aus-eGwDfJbU2WritxxaXw6B4a3flTPojkYLSkPBr6Pi0H2-mBsW_Nvs0aLPVLKobQd4gqTkosX3967DoAG8luUMhrnxe8Q";
 
-import { App } from "../src";
+import { App } from "../src/index.ts";
 
 describe("app.getInstallationOctokit", () => {
   let app: InstanceType<typeof App>;

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -30,7 +30,7 @@ const CLIENT_ID = "0123";
 const CLIENT_SECRET = "0123secret";
 const WEBHOOK_SECRET = "secret";
 
-import { App } from "../src";
+import { App } from "../src/index.ts";
 
 describe("app.log", () => {
   let app: InstanceType<typeof App>;

--- a/test/node-middleware.test.ts
+++ b/test/node-middleware.test.ts
@@ -1,4 +1,4 @@
-import { createServer } from "http";
+import { createServer } from "node:http";
 
 // import without types
 const express = require("express");

--- a/test/node-middleware.test.ts
+++ b/test/node-middleware.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 // import without types
 const express = require("express");
 
-import { App, createNodeMiddleware } from "../src";
+import { App, createNodeMiddleware } from "../src/index.ts";
 
 const APP_ID = 1;
 const PRIVATE_KEY = `-----BEGIN RSA PRIVATE KEY-----

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -28,7 +28,7 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
 -----END RSA PRIVATE KEY-----`;
 const WEBHOOK_SECRET = "secret";
 
-import { App } from "../src";
+import { App } from "../src/index.ts";
 
 describe("app.oauth", () => {
   test("options.oauth is optional", async () => {

--- a/test/octokit.test.ts
+++ b/test/octokit.test.ts
@@ -37,7 +37,7 @@ const WEBHOOK_SECRET = "secret";
 const BEARER =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOi0zMCwiZXhwIjo1NzAsImlzcyI6MX0.q3foRa78U3WegM5PrWLEh5N0bH1SD62OqW66ZYzArp95JBNiCbo8KAlGtiRENCIfBZT9ibDUWy82cI4g3F09mdTq3bD1xLavIfmTksIQCz5EymTWR5v6gL14LSmQdWY9lSqkgUG0XCFljWUglEP39H4yeHbFgdjvAYg3ifDS12z9oQz2ACdSpvxPiTuCC804HkPVw8Qoy0OSXvCkFU70l7VXCVUxnuhHnk8-oCGcKUspmeP6UdDnXk-Aus-eGwDfJbU2WritxxaXw6B4a3flTPojkYLSkPBr6Pi0H2-mBsW_Nvs0aLPVLKobQd4gqTkosX3967DoAG8luUMhrnxe8Q";
 
-import { App } from "../src";
+import { App } from "../src/index.ts";
 
 describe("app.octokit", () => {
   let app: InstanceType<typeof App>;

--- a/test/readme-examples.test.ts
+++ b/test/readme-examples.test.ts
@@ -1,4 +1,4 @@
-import { createServer } from "http";
+import { createServer } from "node:http";
 
 import { Octokit } from "@octokit/core";
 import { request } from "@octokit/request";

--- a/test/readme-examples.test.ts
+++ b/test/readme-examples.test.ts
@@ -40,7 +40,7 @@ const WEBHOOK_SECRET = "secret";
 const BEARER =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOi0zMCwiZXhwIjo1NzAsImlzcyI6MX0.q3foRa78U3WegM5PrWLEh5N0bH1SD62OqW66ZYzArp95JBNiCbo8KAlGtiRENCIfBZT9ibDUWy82cI4g3F09mdTq3bD1xLavIfmTksIQCz5EymTWR5v6gL14LSmQdWY9lSqkgUG0XCFljWUglEP39H4yeHbFgdjvAYg3ifDS12z9oQz2ACdSpvxPiTuCC804HkPVw8Qoy0OSXvCkFU70l7VXCVUxnuhHnk8-oCGcKUspmeP6UdDnXk-Aus-eGwDfJbU2WritxxaXw6B4a3flTPojkYLSkPBr6Pi0H2-mBsW_Nvs0aLPVLKobQd4gqTkosX3967DoAG8luUMhrnxe8Q";
 
-import { App, createNodeMiddleware } from "../src";
+import { App, createNodeMiddleware } from "../src/index.ts";
 
 describe("README examples", () => {
   let app: InstanceType<typeof App>;

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { App, createNodeMiddleware } from "../src";
+import { App, createNodeMiddleware } from "../src/index.ts";
 
 describe("smoke", () => {
   it("App", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -3,7 +3,7 @@
 // ************************************************************
 
 import { Octokit } from "@octokit/core";
-import { App } from "../src";
+import { App } from "../src/index.ts";
 
 function expect<T>(what: T) {}
 

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -30,7 +30,7 @@ const CLIENT_ID = "0123";
 const CLIENT_SECRET = "0123secret";
 const WEBHOOK_SECRET = "webhook_secret";
 
-import { App } from "../src";
+import { App } from "../src/index.ts";
 
 describe("app.webhooks", () => {
   test("options.webhooks is optional", async () => {


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports, and also updates imports to use full relative paths.