### PR TITLE
fix(types): export minimal types required for the `App` class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,16 @@ import type {
   EachRepositoryInterface,
   GetInstallationOctokitInterface,
 } from "./types.js";
+
+// Export types required for the App class
+// This is in order to fix a TypeScript error in downstream projects:
+// The inferred type of 'App' cannot be named without a reference to '../node_modules/@octokit/app/dist-types/types.js'. This is likely not portable. A type annotation is necessary.
+export type {
+  EachInstallationInterface,
+  EachRepositoryInterface,
+  GetInstallationOctokitInterface,
+} from "./types.js";
+
 import { VERSION } from "./version.js";
 import { webhooks } from "./webhooks.js";
 import { eachInstallationFactory } from "./each-installation.js";


### PR DESCRIPTION
This resolves issues in consumers of this package getting errors from TypeScript

```
The inferred type of 'App' cannot be named without a reference to '../node_modules/@octokit/app/dist-types/types.js'. This is likely not portable. A type annotation is necessary.
```

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

