### PR TITLE
ci: remove extraneous command to update `npm`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm
-      - run: npm install --global npm
-        if: ${{ matrix.node_version == 14 }}
       - run: npm ci
       - run: npm test
   test:


### PR DESCRIPTION
It is not used currently

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* There was a command in the `test.yml` workflow file to update NPM that was unused because it was only run on Node 14
* We don't support Node 14 anymore

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Removes the extraneous NPM update that wasn't run

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

