### PR TITLE
fix(deps): bump `@octokit/webhooks` in order to fix web users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/oauth-app": "^7.1.5",
         "@octokit/plugin-paginate-rest": "^11.3.6",
         "@octokit/types": "^13.6.2",
-        "@octokit/webhooks": "^13.4.2"
+        "@octokit/webhooks": "^13.5.1"
       },
       "devDependencies": {
         "@octokit/tsconfig": "^4.0.0",
@@ -863,23 +863,23 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.4.2.tgz",
-      "integrity": "sha512-fakbgkCScapQXPxyqx2jZs/Y3jGlyezwUp7ATL7oLAGJ0+SqBKWKstoKZpiQ+REeHutKpYjY9UtxdLSurwl2Tg==",
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.5.1.tgz",
+      "integrity": "sha512-2q5xt+UEkElPjcRuE5QAEkgsL5WhWa7/vMeWIklhM7BTH86hxQedm20OO0BvEYRyNnOwEj/CpQCB0K9QYt2+ug==",
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-webhooks-types": "8.5.1",
         "@octokit/request-error": "^6.1.6",
-        "@octokit/webhooks-methods": "^5.0.0"
+        "@octokit/webhooks-methods": "^5.1.1"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/webhooks-methods": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-5.1.0.tgz",
-      "integrity": "sha512-yFZa3UH11VIxYnnoOYCVoJ3q4ChuSOk2IVBBQ0O3xtKX4x9bmKb/1t+Mxixv2iUhzMdOl1qeWJqEhouXXzB3rQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-5.1.1.tgz",
+      "integrity": "sha512-NGlEHZDseJTCj8TMMFehzwa9g7On4KJMPVHDSrHxCQumL6uSQR8wIkP/qesv52fXqV1BPf4pTxwtS31ldAt9Xg==",
       "license": "MIT",
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@octokit/oauth-app": "^7.1.5",
     "@octokit/plugin-paginate-rest": "^11.3.6",
     "@octokit/types": "^13.6.2",
-    "@octokit/webhooks": "^13.4.2"
+    "@octokit/webhooks": "^13.5.1"
   },
   "devDependencies": {
     "@octokit/tsconfig": "^4.0.0",


### PR DESCRIPTION


<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `verifyWithFallback()` function was missing from the web code in `@octokit/webhooks-methods`, and was only defined for Node, leaving users unable to use newer versions of `@octokit/webhooks` with this package

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Bump `@octokit/webhooks` to pull in a newer version of `@octokit/webhooks-methods`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

