### PR TITLE
fix(deps): bump `@octokit/types` to v13.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "@octokit/auth-unauthenticated": "^6.1.1",
         "@octokit/core": "^6.1.3",
         "@octokit/oauth-app": "^7.1.5",
-        "@octokit/plugin-paginate-rest": "^11.3.6",
-        "@octokit/types": "^13.6.2",
-        "@octokit/webhooks": "^13.5.1"
+        "@octokit/plugin-paginate-rest": "^11.4.0",
+        "@octokit/types": "^13.8.0",
+        "@octokit/webhooks": "^13.6.0"
       },
       "devDependencies": {
         "@octokit/tsconfig": "^4.0.0",
@@ -798,9 +798,9 @@
       "license": "MIT"
     },
     "node_modules/@octokit/openapi-webhooks-types": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-8.5.1.tgz",
-      "integrity": "sha512-i3h1b5zpGSB39ffBbYdSGuAd0NhBAwPyA3QV3LYi/lx4lsbZiu7u2UHgXVUR6EpvOI8REOuVh1DZTRfHoJDvuQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-9.1.0.tgz",
+      "integrity": "sha512-bO1D2jLdU8qEvqmbWjNxJzDYSFT4wesiYKIKP6f4LaM0XUGtn/0LBv/20hu9YqcnpdX38X5o/xANTMtIAqdwYw==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
@@ -854,21 +854,21 @@
       "license": "MIT"
     },
     "node_modules/@octokit/types": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
-      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^23.0.1"
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.5.1.tgz",
-      "integrity": "sha512-2q5xt+UEkElPjcRuE5QAEkgsL5WhWa7/vMeWIklhM7BTH86hxQedm20OO0BvEYRyNnOwEj/CpQCB0K9QYt2+ug==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.6.0.tgz",
+      "integrity": "sha512-qoYP1g6ZP01m8LtKjC+NLuAqRbiVzS5VmnwoEYlrQr6TaLRtb5yAMxWCq5/AqfrUF2Wx6ZQ9IJ4mAFytEn7J9A==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-webhooks-types": "8.5.1",
+        "@octokit/openapi-webhooks-types": "9.1.0",
         "@octokit/request-error": "^6.1.6",
         "@octokit/webhooks-methods": "^5.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "@octokit/auth-unauthenticated": "^6.1.1",
     "@octokit/core": "^6.1.3",
     "@octokit/oauth-app": "^7.1.5",
-    "@octokit/plugin-paginate-rest": "^11.3.6",
-    "@octokit/types": "^13.6.2",
-    "@octokit/webhooks": "^13.5.1"
+    "@octokit/plugin-paginate-rest": "^11.4.0",
+    "@octokit/types": "^13.8.0",
+    "@octokit/webhooks": "^13.6.0"
   },
   "devDependencies": {
     "@octokit/tsconfig": "^4.0.0",


### PR DESCRIPTION
Bump @octokit/plugin-paginate-rest, @octokit/types, and @octokit/webhooks

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Getting `Property 'paginate' is missing in type 'Octokit' but required in type '{ paginate: PaginateInterface; }'` error related to webhook types.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Bump `@octokit/webhooks` to pull new version of `@octokit/openapi-webhooks-types` that fixes it
* `@octokit/plugin-paginate-rest, @octokit/types` are bumped together

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

