### PR TITLE
feat: new web middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/oauth-app": "^7.1.6",
         "@octokit/plugin-paginate-rest": "^12.0.0",
         "@octokit/types": "^14.0.0",
-        "@octokit/webhooks": "^13.6.1"
+        "@octokit/webhooks": "^13.7.0"
       },
       "devDependencies": {
         "@octokit/tsconfig": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@octokit/oauth-app": "^7.1.6",
     "@octokit/plugin-paginate-rest": "^12.0.0",
     "@octokit/types": "^14.0.0",
-    "@octokit/webhooks": "^13.6.1"
+    "@octokit/webhooks": "^13.7.0"
   },
   "devDependencies": {
     "@octokit/tsconfig": "^4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,3 +164,4 @@ export class App<TOptions extends Options = Options> {
 }
 
 export { createNodeMiddleware } from "./middleware/node/index.js";
+export { createWebMiddleware } from "./middleware/web/index.js";

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -12,12 +12,7 @@ import {
 import { createNodeMiddleware as webhooksNodeMiddleware } from "@octokit/webhooks";
 
 import type { App } from "../../index.js";
-import type { Options } from "../../types.js";
-
-export type MiddlewareOptions = {
-  pathPrefix?: string;
-  log?: Options["log"];
-};
+import type { MiddlewareOptions } from "../types.js";
 
 function noop() {}
 

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -1,0 +1,6 @@
+import type { Options } from "../types.js";
+
+export type MiddlewareOptions = {
+  pathPrefix?: string;
+  log?: Options["log"];
+};

--- a/src/middleware/web/index.ts
+++ b/src/middleware/web/index.ts
@@ -1,0 +1,71 @@
+import { createWebWorkerHandler as oauthWebMiddleware } from "@octokit/oauth-app";
+import { createWebMiddleware as webhooksWebMiddleware } from "@octokit/webhooks";
+
+import type { App } from "../../index.js";
+import type { MiddlewareOptions } from "../types.js";
+
+function noop() {}
+
+export function createWebMiddleware(app: App, options: MiddlewareOptions = {}) {
+  const log = Object.assign(
+    {
+      debug: noop,
+      info: noop,
+      warn: console.warn.bind(console),
+      error: console.error.bind(console),
+    },
+    options.log,
+  );
+
+  const optionsWithDefaults = {
+    pathPrefix: "/api/github",
+    ...options,
+    log,
+  };
+
+  const webhooksMiddleware = webhooksWebMiddleware(app.webhooks, {
+    path: optionsWithDefaults.pathPrefix + "/webhooks",
+    log,
+  });
+
+  const oauthMiddleware = oauthWebMiddleware(app.oauth, {
+    pathPrefix: optionsWithDefaults.pathPrefix + "/oauth",
+  });
+
+  return middleware.bind(
+    null,
+    optionsWithDefaults.pathPrefix,
+    webhooksMiddleware,
+    oauthMiddleware,
+  );
+}
+export async function middleware(
+  pathPrefix: string,
+  webhooksMiddleware: ReturnType<typeof webhooksWebMiddleware>,
+  oauthMiddleware: ReturnType<typeof oauthWebMiddleware>,
+  request: Request,
+): Promise<Response | undefined> {
+  const { pathname } = new URL(request.url as string, "http://localhost");
+
+  if (pathname.startsWith(`${pathPrefix}/`)) {
+    if (pathname === `${pathPrefix}/webhooks`) {
+      return webhooksMiddleware(request);
+    } else if (pathname.startsWith(`${pathPrefix}/oauth/`)) {
+      return oauthMiddleware(request);
+    } else {
+      return new Response(
+        JSON.stringify({
+          error: `Unknown route: ${request.method} ${request.url}`,
+        }),
+        {
+          status: 404,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    }
+  } else {
+    return undefined;
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #623 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Users of platforms that don't have the `unref()` function property on `setTimeout` would get errors
* No web standard middleware was exported

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds a new web standards middleware
* Bumps the required version of `@octokit/webhooks` to `v18.7.0`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

